### PR TITLE
build: bump bindgen 0.60 -> 0.61.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ documentation = "https://docs.rs/fts-sys"
 libc = { version = "0.2" }
 
 [build-dependencies]
-bindgen = { version = "0.60" }
+bindgen = { version = "0.61.0" }


### PR DESCRIPTION
The new version of `bindgen` doesn't depend on "heavy" `clap` by default. 